### PR TITLE
fix(favorites): fix 3 bugs preventing favorite→tracker flow

### DIFF
--- a/evals/test_favorite_to_tracker_e2e.py
+++ b/evals/test_favorite_to_tracker_e2e.py
@@ -1,0 +1,276 @@
+"""E2E eval — Add favorite recipe to daily food tracker.
+
+WHY THIS IS AN EVAL, NOT A TEST
+================================
+This tests a multi-step LLM workflow:
+  1. Agent routes to get_user_favorites (meal-planning skill)
+  2. Agent extracts ingredients from the favorite
+  3. Agent routes to log_food_entries (food-tracking skill) with decomposed ingredients
+  4. Agent does NOT log the recipe name as a single opaque item
+
+Outcomes are non-deterministic → scored criteria, not exact assertions.
+Run on demand before releases, NOT in CI.
+
+    pytest evals/test_favorite_to_tracker_e2e.py -m integration -v -s
+
+TEST PERSONA — Marc (real user in DB with favorites)
+=====================================================
+User ID:         5745fc58-9c75-48b1-bc79-12855a8c6021
+"""
+
+import json
+import time
+from dataclasses import dataclass, field
+
+import pytest
+from pydantic_ai.messages import ToolCallPart
+from pydantic_evals import Case, Dataset
+from pydantic_evals.evaluators import (
+    Evaluator,
+    EvaluationReason,
+    EvaluatorContext,
+    MaxDuration,
+)
+
+from src.agent import agent, create_agent_deps
+
+# ---------------------------------------------------------------------------
+# Test persona
+# ---------------------------------------------------------------------------
+
+TEST_USER_ID = "5745fc58-9c75-48b1-bc79-12855a8c6021"
+
+TEST_USER_PROFILE = {
+    "age": 24,
+    "gender": "male",
+    "height_cm": 191,
+    "weight_kg": 86.0,
+    "activity_level": "light",
+    "goal": "muscle_gain",
+    "diet_type": "omnivore",
+    "allergies": ["arachides", "cacahuètes"],
+    "disliked_foods": ["fromage", "choux de Bruxelles"],
+    "preferred_cuisines": ["française", "méditerranéenne"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Structured output
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentResult:
+    text: str
+    tool_calls: list[dict]
+    elapsed_seconds: float = 0.0
+
+    def __str__(self) -> str:
+        return self.text
+
+
+# ---------------------------------------------------------------------------
+# Evaluators
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NoRefusal(Evaluator):
+    """Check the agent did not refuse the task."""
+
+    evaluation_name: str | None = field(default=None)
+
+    _REFUSAL_PHRASES = [
+        "je ne peux pas",
+        "je suis incapable",
+        "désolé, je ne",
+        "impossible de",
+        "i cannot",
+        "i'm unable",
+    ]
+
+    def evaluate(self, ctx: EvaluatorContext) -> EvaluationReason:
+        text = str(ctx.output).lower()
+        for phrase in self._REFUSAL_PHRASES:
+            if phrase in text:
+                return EvaluationReason(
+                    value=False, reason=f"Refusal detected: '{phrase}'"
+                )
+        return EvaluationReason(value=True, reason="No refusal detected")
+
+
+@dataclass
+class ScriptWasCalled(Evaluator):
+    """Check that a specific script_name was passed to run_skill_script."""
+
+    script_name: str
+    evaluation_name: str | None = field(default=None)
+
+    def evaluate(self, ctx: EvaluatorContext) -> EvaluationReason:
+        result: AgentResult = ctx.output
+        scripts_called = [
+            tc["args"].get("script_name", "")
+            for tc in result.tool_calls
+            if tc["name"] == "run_skill_script"
+        ]
+        if self.script_name in scripts_called:
+            return EvaluationReason(
+                value=True,
+                reason=f"Script '{self.script_name}' was called (all: {scripts_called})",
+            )
+        return EvaluationReason(
+            value=False,
+            reason=f"Script '{self.script_name}' not called. Called: {scripts_called}",
+        )
+
+
+@dataclass
+class LogFoodHasMultipleItems(Evaluator):
+    """Check that log_food_entries was called with >1 items (decomposed ingredients)."""
+
+    evaluation_name: str | None = field(default=None)
+
+    def evaluate(self, ctx: EvaluatorContext) -> EvaluationReason:
+        result: AgentResult = ctx.output
+        for tc in result.tool_calls:
+            if tc["name"] != "run_skill_script":
+                continue
+            if tc["args"].get("script_name") != "log_food_entries":
+                continue
+            params = tc["args"].get("parameters", {})
+            items = params.get("items", [])
+            if len(items) > 1:
+                names = [i.get("name", "?") for i in items]
+                return EvaluationReason(
+                    value=True,
+                    reason=f"log_food_entries called with {len(items)} items: {names}",
+                )
+            if len(items) == 1:
+                return EvaluationReason(
+                    value=False,
+                    reason=f"log_food_entries called with only 1 item: {items[0].get('name', '?')} — recipe was not decomposed",
+                )
+        return EvaluationReason(
+            value=False,
+            reason="log_food_entries was not called at all",
+        )
+
+
+@dataclass
+class BothSkillsUsed(Evaluator):
+    """Check that both meal-planning and food-tracking skills were loaded."""
+
+    evaluation_name: str | None = field(default=None)
+
+    def evaluate(self, ctx: EvaluatorContext) -> EvaluationReason:
+        result: AgentResult = ctx.output
+        skills_loaded = set()
+        for tc in result.tool_calls:
+            if tc["name"] == "load_skill":
+                skills_loaded.add(tc["args"].get("skill_name", ""))
+            elif tc["name"] == "run_skill_script":
+                skills_loaded.add(tc["args"].get("skill_name", ""))
+        has_mp = "meal-planning" in skills_loaded
+        has_ft = "food-tracking" in skills_loaded
+        if has_mp and has_ft:
+            return EvaluationReason(
+                value=True, reason=f"Both skills used: {skills_loaded}"
+            )
+        missing = []
+        if not has_mp:
+            missing.append("meal-planning")
+        if not has_ft:
+            missing.append("food-tracking")
+        return EvaluationReason(
+            value=False, reason=f"Missing skills: {missing}. Loaded: {skills_loaded}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task function
+# ---------------------------------------------------------------------------
+
+
+async def _run_agent(message: str) -> AgentResult:
+    """Run agent as the test user."""
+    deps = create_agent_deps(user_id=TEST_USER_ID)
+    t0 = time.monotonic()
+    result = await agent.run(message, deps=deps)
+    elapsed = time.monotonic() - t0
+
+    tool_calls = []
+    for msg in result.all_messages():
+        for part in getattr(msg, "parts", []):
+            if isinstance(part, ToolCallPart):
+                args = part.args
+                if isinstance(args, str):
+                    args = json.loads(args)
+                tool_calls.append({"name": part.tool_name, "args": args})
+
+    return AgentResult(
+        text=result.output, tool_calls=tool_calls, elapsed_seconds=elapsed
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario — Add favorite to tracker
+# ---------------------------------------------------------------------------
+
+
+def scenario_favorite_to_tracker() -> Dataset:
+    """User asks to add a favorite recipe to today's tracker.
+
+    Expected flow:
+    1. load_skill('meal-planning') + get_user_favorites(name='poulet')
+    2. load_skill('food-tracking') + log_food_entries(items=[decomposed ingredients])
+    """
+    return Dataset(
+        name="favorite_to_tracker",
+        cases=[
+            Case(
+                name="add_favorite_poulet_to_tracker",
+                inputs="Ajoute ma recette favorite de poulet grillé à mon suivi du jour pour le déjeuner",
+                evaluators=(
+                    NoRefusal(evaluation_name="no_refusal"),
+                    BothSkillsUsed(evaluation_name="both_skills_used"),
+                    ScriptWasCalled(
+                        script_name="get_user_favorites",
+                        evaluation_name="fetched_favorites",
+                    ),
+                    ScriptWasCalled(
+                        script_name="log_food_entries",
+                        evaluation_name="logged_food",
+                    ),
+                    LogFoodHasMultipleItems(
+                        evaluation_name="ingredients_decomposed",
+                    ),
+                ),
+            ),
+            Case(
+                name="add_favorite_generic_to_tracker",
+                inputs="Mets mon favori dans mon suivi d'aujourd'hui",
+                evaluators=(
+                    NoRefusal(evaluation_name="no_refusal"),
+                    ScriptWasCalled(
+                        script_name="get_user_favorites",
+                        evaluation_name="fetched_favorites",
+                    ),
+                ),
+            ),
+        ],
+        evaluators=[MaxDuration(seconds=120.0)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pytest entry points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_favorite_to_tracker():
+    """Eval: 'ajoute ma recette favorite au suivi' → full cross-skill flow."""
+    dataset = scenario_favorite_to_tracker()
+    report = await dataset.evaluate(task=_run_agent)
+    report.print(include_input=True, include_output=True)
+    assert len(report.failures) == 0, f"Failures: {[f.name for f in report.failures]}"

--- a/skills/food-tracking/SKILL.md
+++ b/skills/food-tracking/SKILL.md
@@ -49,6 +49,12 @@ Ex : "pates carbonara" → pates 150g + lardons 50g + creme 30ml + oeuf 1 + parm
 
 **Lecture du tracker** : Quand l'utilisateur demande ce qu'il a mange ou veut voir son suivi, appeler `get_daily_summary`. La reponse inclut `meals_detail` avec chaque aliment (nom, quantite, unite, macros) groupe par repas — utile pour repondre a "qu'est-ce que j'ai mange ce matin ?" ou reutiliser un repas dans un plan.
 
+**Recette favorite → tracker** : Quand l'utilisateur demande d'ajouter une recette favorite a son suivi :
+1. Appeler `get_user_favorites` (skill `meal-planning`) avec le nom de la recette
+2. Le resultat contient `ingredients` (liste `{name, quantity, unit}`) — les extraire
+3. Passer ces ingredients a `log_food_entries` avec le `meal_type` du favori
+Ne JAMAIS logger le nom de la recette comme un seul aliment — toujours decomposer en ingredients.
+
 ## Exemples
 
 ```python
@@ -81,6 +87,20 @@ run_skill_script("food-tracking", "log_food_entries", {
     "entry_id": "uuid-de-l-entree",
     "items": [{"name": "skyr", "quantity": 200, "unit": "g"}],
     "meal_type": "petit-dejeuner"
+})
+
+# Ajouter un favori au tracker (2 etapes)
+# Etape 1 : recuperer le favori et ses ingredients
+run_skill_script("meal-planning", "get_user_favorites", {"name": "poulet grillé"})
+# → retourne ingredients: [{"name": "poulet", "quantity": 200, "unit": "g"}, ...]
+
+# Etape 2 : logger les ingredients individuels
+run_skill_script("food-tracking", "log_food_entries", {
+    "items": [
+        {"name": "poulet", "quantity": 200, "unit": "g"},
+        {"name": "herbes de provence", "quantity": 5, "unit": "g"}
+    ],
+    "meal_type": "dejeuner"
 })
 
 # Bilan du jour

--- a/skills/meal-planning/SKILL.md
+++ b/skills/meal-planning/SKILL.md
@@ -59,7 +59,7 @@ category: planning
 | `generate_custom_recipe` | Recette unique sur demande |
 | `fetch_stored_meal_plan` | Récupérer un plan existant |
 | `add_favorite_recipe` | Ajouter une recette aux favoris de l'utilisateur |
-| `get_user_favorites` | Lister les recettes favorites de l'utilisateur (avec filtre optionnel par nom) |
+| `get_user_favorites` | Lister les recettes favorites avec macros + ingredients (filtre optionnel par nom) |
 | `remove_favorite_recipe` | Supprimer une recette des favoris |
 
 ```python

--- a/skills/meal-planning/scripts/get_user_favorites.py
+++ b/skills/meal-planning/scripts/get_user_favorites.py
@@ -43,23 +43,26 @@ async def execute(**kwargs) -> str:
                 "created_at": fav.get("created_at"),
                 "recipe_name": recipe_data.get("name"),
                 "meal_type": recipe_data.get("meal_type"),
-                "calories": recipe_data.get("calories"),
-                "protein_g": recipe_data.get("protein_g"),
-                "carbs_g": recipe_data.get("carbs_g"),
-                "fat_g": recipe_data.get("fat_g"),
+                "calories": recipe_data.get("calories_per_serving"),
+                "protein_g": recipe_data.get("protein_g_per_serving"),
+                "carbs_g": recipe_data.get("carbs_g_per_serving"),
+                "fat_g": recipe_data.get("fat_g_per_serving"),
+                "ingredients": recipe_data.get("ingredients", []),
             }
         )
 
     # Apply fuzzy name filter if provided
     if name:
-        query_words = set(re.sub(r"[^\w\s]", "", name.lower()).split())
+        query_words = set(re.sub(r"[^\w\s]", " ", name.lower()).split())
         favorites = [
             f
             for f in favorites
             if query_words
             and query_words.issubset(
                 set(
-                    re.sub(r"[^\w\s]", "", (f.get("recipe_name") or "").lower()).split()
+                    re.sub(
+                        r"[^\w\s]", " ", (f.get("recipe_name") or "").lower()
+                    ).split()
                 )
             )
         ]

--- a/tests/test_get_user_favorites.py
+++ b/tests/test_get_user_favorites.py
@@ -26,6 +26,11 @@ execute = _mod.execute
 
 USER_ID = "1111-2222-3333-4444"
 
+_INGREDIENTS_POULET = [
+    {"name": "poulet", "quantity": 200, "unit": "g"},
+    {"name": "herbes de provence", "quantity": 5, "unit": "g"},
+]
+
 FAV_1 = {
     "id": "fav-1",
     "recipe_id": "recipe-1",
@@ -35,10 +40,11 @@ FAV_1 = {
     "recipes": {
         "name": "Poulet grillé aux herbes",
         "meal_type": "dejeuner",
-        "calories": 550,
-        "protein_g": 45,
-        "carbs_g": 30,
-        "fat_g": 20,
+        "calories_per_serving": 550,
+        "protein_g_per_serving": 45,
+        "carbs_g_per_serving": 30,
+        "fat_g_per_serving": 20,
+        "ingredients": _INGREDIENTS_POULET,
     },
 }
 
@@ -51,10 +57,11 @@ FAV_2 = {
     "recipes": {
         "name": "Saumon teriyaki et riz",
         "meal_type": "diner",
-        "calories": 620,
-        "protein_g": 40,
-        "carbs_g": 55,
-        "fat_g": 18,
+        "calories_per_serving": 620,
+        "protein_g_per_serving": 40,
+        "carbs_g_per_serving": 55,
+        "fat_g_per_serving": 18,
+        "ingredients": [{"name": "saumon", "quantity": 150, "unit": "g"}],
     },
 }
 
@@ -67,10 +74,31 @@ FAV_3 = {
     "recipes": {
         "name": "Poulet tikka masala",
         "meal_type": "dejeuner",
-        "calories": 580,
-        "protein_g": 42,
-        "carbs_g": 45,
-        "fat_g": 22,
+        "calories_per_serving": 580,
+        "protein_g_per_serving": 42,
+        "carbs_g_per_serving": 45,
+        "fat_g_per_serving": 22,
+        "ingredients": [{"name": "poulet", "quantity": 250, "unit": "g"}],
+    },
+}
+
+FAV_HYPHEN = {
+    "id": "fav-4",
+    "recipe_id": "recipe-4",
+    "user_id": USER_ID,
+    "notes": None,
+    "created_at": "2026-03-04T12:00:00Z",
+    "recipes": {
+        "name": "Bol Petit-Déjeuner Protéiné Équilibré",
+        "meal_type": "petit-dejeuner",
+        "calories_per_serving": 480,
+        "protein_g_per_serving": 35,
+        "carbs_g_per_serving": 50,
+        "fat_g_per_serving": 12,
+        "ingredients": [
+            {"name": "flocons d'avoine", "quantity": 80, "unit": "g"},
+            {"name": "skyr", "quantity": 150, "unit": "g"},
+        ],
     },
 }
 
@@ -132,6 +160,26 @@ class TestGetUserFavoritesHappyPath:
         assert fav["protein_g"] == 45
         assert fav["meal_type"] == "dejeuner"
         assert fav["notes"] == "Très bon"
+
+    @pytest.mark.asyncio
+    async def test_includes_ingredients(self):
+        sb = _mock_supabase(fav_data=[FAV_1])
+        result = json.loads(await execute(supabase=sb, user_id=USER_ID))
+        fav = result["favorites"][0]
+        assert fav["ingredients"] == _INGREDIENTS_POULET
+
+    @pytest.mark.asyncio
+    async def test_hyphenated_name_filter(self):
+        """'petit déjeuner' matches 'Bol Petit-Déjeuner Protéiné Équilibré'."""
+        sb = _mock_supabase(fav_data=[FAV_1, FAV_HYPHEN])
+        result = json.loads(
+            await execute(supabase=sb, user_id=USER_ID, name="bol petit")
+        )
+        assert result["count"] == 1
+        assert (
+            result["favorites"][0]["recipe_name"]
+            == "Bol Petit-Déjeuner Protéiné Équilibré"
+        )
 
     @pytest.mark.asyncio
     async def test_skips_favorites_without_recipe_data(self):


### PR DESCRIPTION
## Summary
- **Regex tirets**: `re.sub(r"[^\w\s]", "")` → `" "` — "Petit-Déjeuner" matchait plus en recherche fuzzy
- **Champs macros**: `calories` → `calories_per_serving` (idem protein/carbs/fat) — macros retournaient null
- **Ingrédients manquants**: `get_user_favorites` retourne maintenant `ingredients[]` pour que l'agent puisse décomposer et logger via `log_food_entries`
- **SKILL.md guidance**: workflow cross-skill documenté dans food-tracking + meal-planning
- **Eval**: `test_favorite_to_tracker_e2e.py` — 2 scénarios, 5 evaluators

## Test plan
- [x] 9/9 unit tests pass (`tests/test_get_user_favorites.py`)
- [ ] Run eval with DB access: `pytest evals/test_favorite_to_tracker_e2e.py -m integration -v -s`
- [ ] Test manuellement: "ajoute ma recette favorite X à mon suivi du jour"

🤖 Generated with [Claude Code](https://claude.com/claude-code)